### PR TITLE
Upgrade gdal for compatibility with more Node versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "homepage": "https://github.com/scisco/gdalinfo-json.git",
   "dependencies": {
     "extend": "^2.0.1",
-    "gdal": "^0.4.4",
+    "gdal": "^0.9.4",
     "mt-geo": "^1.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Another consideration would be moving `gdal` to a peer dependency and relaxing the version requirement to `>= <min version>`.

Context: updating oam-uploader-api to use Node 4.x.